### PR TITLE
Update code-of-conduct.md

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,63 +1,93 @@
-# Google Open Source Community Guidelines
+# Code of Conduct
 
-At Google, we recognize and celebrate the creativity and collaboration of open
-source contributors and the diversity of skills, experiences, cultures, and
-opinions they bring to the projects and communities they participate in.
+## Our Pledge
 
-Every one of Google's open source projects and communities are inclusive
-environments, based on treating all individuals respectfully, regardless of
-gender identity and expression, sexual orientation, disabilities,
-neurodiversity, physical appearance, body size, ethnicity, nationality, race,
-age, religion, or similar personal characteristic.
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of
+experience, education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
 
-We value diverse opinions, but we value respectful behavior more.
+## Our Standards
 
-Respectful behavior includes:
+Examples of behavior that contributes to creating a positive environment
+include:
 
-* Being considerate, kind, constructive, and helpful.
-* Not engaging in demeaning, discriminatory, harassing, hateful, sexualized, or
-  physically threatening behavior, speech, and imagery.
-* Not engaging in unwanted physical contact.
+*   Using welcoming and inclusive language
+*   Being respectful of differing viewpoints and experiences
+*   Gracefully accepting constructive criticism
+*   Focusing on what is best for the community
+*   Showing empathy towards other community members
 
-Some Google open source projects [may adopt][] an explicit project code of
-conduct, which may have additional detailed expectations for participants. Most
-of those projects will use our [modified Contributor Covenant][].
+Examples of unacceptable behavior by participants include:
 
-[may adopt]: https://opensource.google/docs/releasing/preparing/#conduct
-[modified Contributor Covenant]: https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/
+*   The use of sexualized language or imagery and unwelcome sexual attention or
+    advances
+*   Trolling, insulting/derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or electronic
+    address, without explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
 
-## Resolve peacefully
+## Our Responsibilities
 
-We do not believe that all conflict is necessarily bad; healthy debate and
-disagreement often yields positive results. However, it is never okay to be
-disrespectful.
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
 
-If you see someone behaving disrespectfully, you are encouraged to address the
-behavior directly with those involved. Many issues can be resolved quickly and
-easily, and this gives people more control over the outcome of their dispute.
-If you are unable to resolve the matter for any reason, or if the behavior is
-threatening or harassing, report it. We are dedicated to providing an
-environment where participants feel welcome and safe.
+Project maintainers have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, or to ban temporarily or permanently any
+contributor for other behaviors that they deem inappropriate, threatening,
+offensive, or harmful.
 
-## Reporting problems
+## Scope
 
-Some Google open source projects may adopt a project-specific code of conduct.
-In those cases, a Google employee will be identified as the Project Steward,
-who will receive and handle reports of code of conduct violations. In the event
-that a project hasn’t identified a Project Steward, you can report problems by
-emailing opensource@google.com.
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+This Code of Conduct also applies outside the project spaces when the Project
+Steward has a reasonable belief that an individual's behavior may have a
+negative impact on the project or its community.
+
+## Conflict Resolution
+
+We do not believe that all conflict is bad; healthy debate and disagreement
+often yield positive results. However, it is never okay to be disrespectful or
+to engage in behavior that violates the project’s code of conduct.
+
+If you see someone violating the code of conduct, you are encouraged to address
+the behavior directly with those involved. Many issues can be resolved quickly
+and easily, and this gives people more control over the outcome of their
+dispute. If you are unable to resolve the matter for any reason, or if the
+behavior is threatening or harassing, report it. We are dedicated to providing
+an environment where participants feel welcome and safe.
+
+Reports should be directed to *[PROJECT STEWARD NAME(s) AND EMAIL(s)]*, the
+Project Steward(s) for *[PROJECT NAME]*. It is the Project Steward’s duty to
+receive and address reported violations of the code of conduct. They will then
+work with a committee consisting of representatives from the Open Source
+Programs Office and the Google Open Source Strategy team. If for any reason you
+are uncomfortable reaching out to the Project Steward, please email
+opensource@google.com.
 
 We will investigate every complaint, but you may not receive a direct response.
 We will use our discretion in determining when and how to follow up on reported
 incidents, which may range from not taking action to permanent expulsion from
 the project and project-sponsored spaces. We will notify the accused of the
-report and provide them an opportunity to discuss it before any action is
-taken. The identity of the reporter will be omitted from the details of the
-report supplied to the accused. In potentially harmful situations, such as
-ongoing harassment or threats to anyone's safety, we may take action without
-notice.
+report and provide them an opportunity to discuss it before any action is taken.
+The identity of the reporter will be omitted from the details of the report
+supplied to the accused. In potentially harmful situations, such as ongoing
+harassment or threats to anyone's safety, we may take action without notice.
 
-*This document was adapted from the [IndieWeb Code of Conduct][] and can also
-be found at <https://opensource.google/conduct/>.*
+## Attribution
 
-[IndieWeb Code of Conduct]: https://indieweb.org/code-of-conduct
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
+available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html


### PR DESCRIPTION
Make the code of conduct match https://opensource.google/docs/releasing/template/CODE_OF_CONDUCT/ instead of https://opensource.google/conduct/