### PR TITLE
Update Apache license header year to 2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ doesn't comply with the license.)
 
 Apache header:
 
-    Copyright 2020 Google LLC
+    Copyright 2021 Google LLC
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #30 