### PR TITLE
Update external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a template that can be used to seed a repository for a
 new Google open source project.
 
 See [go/releasing](http://go/releasing) (available externally at
-https://opensource.google/docs/releasing/) for more information about
+https://opensource.google/documentation/reference/releasing) for more information about
 releasing a new Google open source project.
 
 This template uses the Apache license, as is Google's default.  See the

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -90,4 +90,4 @@ harassment or threats to anyone's safety, we may take action without notice.
 
 This Code of Conduct is adapted from the Contributor Covenant, version 1.4,
 available at
-https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+https://www.contributor-covenant.org/version/1/4/code-of-conduct/

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -28,5 +28,5 @@ Guidelines](https://opensource.google/conduct/).
 ### Code Reviews
 
 All submissions, including submissions by project members, require review. We 
-use [GitHub pull requests](https://help.github.com/articles/about-pull-requests/)
+use [GitHub pull requests](https://docs.github.com/articles/about-pull-requests)
 for this purpose.


### PR DESCRIPTION
Some external links respond with the HTTP status code 301 (moved permanently).

This pull request update those external links to their new locations.