### PR TITLE
Remove go link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 This repository contains a template that can be used to seed a repository for a
 new Google open source project.
 
-See [go/releasing](http://go/releasing) (available externally at
-https://opensource.google/documentation/reference/releasing) for more information about
-releasing a new Google open source project.
+See [Go Releasing](https://opensource.google/documentation/reference/releasing) 
+for more information about releasing a new Google open source project.
 
 This template uses the Apache license, as is Google's default.  See the
 documentation for instructions on using alternate license.


### PR DESCRIPTION
autocross flags go links as a "potential" issue, meaning you always need  to make further changes to get cross to pass your launch, if you base your repository off this template.
