### PR TITLE
Add a spam example to the unacceptable list

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -28,6 +28,8 @@ Examples of unacceptable behavior by participants include:
 *   Public or private harassment
 *   Publishing others' private information, such as a physical or electronic
     address, without explicit permission
+*   Disrespecting the community's time by spamming or posting non-productive
+    commentary
 *   Other conduct which could reasonably be considered inappropriate in a
     professional setting
 

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -28,8 +28,8 @@ Examples of unacceptable behavior by participants include:
 *   Public or private harassment
 *   Publishing others' private information, such as a physical or electronic
     address, without explicit permission
-*   Disrespecting the community's time by spamming or posting non-productive
-    commentary
+*   Disrespecting the community's time by sending spam or other unsolicited
+    commercial messages
 *   Other conduct which could reasonably be considered inappropriate in a
     professional setting
 


### PR DESCRIPTION
GitHub points users to the code of conduct when they are blocked, but we don't mention spamming explicitly in the list.

We get a fair bit of spammy comment activity on our repositories ([e.g.](https://screenshot.googleplex.com/CvaNcwbyFM7qRJL)), and I can update our own COC but this seems relevant to any Google project on GitHub so I am proposing the change here.