### PR TITLE
replace the legacy ISSUE_TEMPLATE.md file

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
 ## Expected Behavior
 
 


### PR DESCRIPTION
The single issue templates (ISSUE_TEMPLATE.md) GitHub feature [will be retired](https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#single-issue-templates-issue_template-md-will-be-retired) on March 30th, 2025.

This PR should update the template to use the new `ISSUE_TEMPLATE/` directory.